### PR TITLE
Remove `get_event_loop()`

### DIFF
--- a/allms/models/abstract.py
+++ b/allms/models/abstract.py
@@ -65,7 +65,14 @@ class AbstractModel(ABC):
             raise ValueError("max_output_tokens has to be lower than model_total_max_tokens")
 
         self._llm = self._create_llm()
-        self._event_loop = event_loop if event_loop is not None else asyncio.get_event_loop()
+
+        if not event_loop:
+            try:
+                event_loop = asyncio.get_running_loop()
+            except RuntimeError as error:
+                event_loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(event_loop)
+        self._event_loop = event_loop
 
         self._predict_example = create_base_retry_decorator(
             error_types=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "allms"
-version = "1.0.2"
+version = "1.0.3"
 description = ""
 authors = ["Allegro Opensource <opensource@allegro.com>"]
 readme = "README.md"


### PR DESCRIPTION
### Feature Description

`asyncio.get_event_loop()` returns a new event loop only if called from the main thread. This causes problems and also this function is not recommended by python docs. They recommend to use `asyncio.get_running_loop()`

#### Changed
`asyncio.get_event_loop()` changed to `asyncio.get_running_loop()`

