### PR TITLE
Handle empty responses from VertexAI properly

### DIFF
--- a/allms/models/abstract.py
+++ b/allms/models/abstract.py
@@ -32,6 +32,7 @@ from allms.domain.enumerables import AggregationLogicForLongInputData, LanguageM
 from allms.domain.input_data import InputData
 from allms.domain.prompt_dto import SummaryOutputClass, KeywordsOutputClass
 from allms.domain.response import ResponseData
+from allms.models.vertexai_base import GCPInvalidRequestError
 from allms.utils.long_text_processing_utils import get_max_allowed_number_of_tokens
 from allms.utils.response_parsing_utils import ResponseParser
 
@@ -260,7 +261,7 @@ class AbstractModel(ABC):
                 model_response = None
                 error_message = f"{IODataConstants.ERROR_MESSAGE_STR}: {invalid_request_error}"
 
-        except (InvalidArgument, ValueError, TimeoutError, openai.error.Timeout) as other_error:
+        except (InvalidArgument, ValueError, TimeoutError, openai.error.Timeout, GCPInvalidRequestError) as other_error:
             model_response = None
             logger.info(f"Error for id {input_data.id} has occurred. Message: {other_error} ")
             error_message = f"{type(other_error).__name__}: {other_error}"

--- a/allms/models/vertexai_base.py
+++ b/allms/models/vertexai_base.py
@@ -9,6 +9,10 @@ from pydash import chain
 from allms.constants.vertex_ai import VertexModelConstants
 
 
+class GCPInvalidRequestError(Exception):
+    pass
+
+
 class CustomVertexAI(VertexAI):
     async def _agenerate(
         self,
@@ -30,6 +34,9 @@ class CustomVertexAI(VertexAI):
             run_manager=run_manager,
             **kwargs
         )
+
+        if not all(result.generations):
+            raise GCPInvalidRequestError("The response is empty. It may have been blocked due to content filtering.")
 
         return LLMResult(
             generations=(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "allms"
-version = "1.0.8"
+version = "1.0.9"
 description = ""
 authors = ["Allegro Opensource <opensource@allegro.com>"]
 readme = "README.md"


### PR DESCRIPTION
### Feature Description
Due to a bug in `langchain`, the response is empty if the request was blocked because of a prompt being unsafe. We catch it here and raise a proper exception

#### Fixed
- Raise exception if an empty response was returned from VertexAI

